### PR TITLE
You can now choose the apn, and ask for the connection type

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,18 @@ var dongle = new machina.Fsm({
     smsQueue: [],
     sendingSMS: false,
     modemInitializedOnce: false,
+    networkType: 0,
 
     initialState: "uninitialized",
+
+    getNetworkType: function() {
+        return dongle.networkType;
+    },
+
+    askNetworkType: function() {
+        debug("asking for the network type");
+        this.smsPort.write("AT^SYSINFO\r");
+    },
 
     cleanProcess: function(process){
 
@@ -179,6 +189,11 @@ var dongle = new machina.Fsm({
                     console.log("error in watchATmsg for CREG", err);
                 }
             }
+            // network type (EDGE, 3G, 3G+)
+            if (message.match(/SYSINFO:\d,\d,\d,\d,\d,\d,(\d)/)) {
+                dongle.networkType = parseInt(message.match(/SYSINFO:\d,\d,\d,\d,\d,\d,(\d)/)[1]);
+                debug("networkType : " + dongle.networkType);
+            }
         });
     },
 
@@ -289,7 +304,7 @@ var dongle = new machina.Fsm({
             _onEnter: function(){
                 debug('INITIALIZED');
             },
-            "open3G": function() {
+            "open3G": function(apn) {
 
                 var self = this;
 
@@ -299,7 +314,7 @@ var dongle = new machina.Fsm({
                         self.watchATonModem();                            
                         self.modemPort.write('ATH\r');
                         self.modemPort.write("ATE1\r");
-                        self.modemPort.write('AT+CGDCONT=1,"IP","free"\r');
+                        self.modemPort.write('AT+CGDCONT=1,"IP",' + apn ? apn : "free" + '\r');
                         self.modemPort.write("ATD*99#\r");
                     })
                     .catch(function(err){


### PR DESCRIPTION
### 2 features added :
#### You can choose the apn (mobile operator) when using open3G (if not set, the apn will be "Free")

It's usefull, in order to use a m2m SIM, for example.
#### Added a method to get the connection type (GPRS / EDGE / 3G / H(3G+) / H+ / 4G)

Be warning : the value returned are those that AT^SYSINFO return (the last value) :
[AT^SYSINFO documentation here](http://m2msupport.net/m2msupport/atsysinfo-get-the-system-mode/)
